### PR TITLE
Implement specs' VCR labeling (through spec metadata)

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,4 +72,8 @@ RSpec.configure do |config|
   config.before do
     stub_strong_password
   end
+  config.around do |example|
+    vcr = example.metadata[:vcr]
+    vcr ? example.run : VCR.turned_off { example.run }
+  end
 end


### PR DESCRIPTION
A solution proposed by @hcarreras

We noticed in another project that VCR is global for all specs, but there are some specs where you don't want VCR to interfere.

Even though VCR is hooked into webmock, if you haven't mocked the request correctly VCR will take precedence and you won't be able to see the mocking error.

This solution proposes that specs should have vcr: true in their metadata, e.g.

`RSpec.describe MyController, type: controller, vcr: true`

Co-authored-by: hcarreras <hc@abtion.com>