### PR TITLE
puma: Remove preload_app!, it is default

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -34,12 +34,5 @@ pidfile(ENV.fetch("PIDFILE", "tmp/pids/server.pid"))
 #
 workers(ENV.fetch("WEB_CONCURRENCY", 2))
 
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-preload_app!
-
 # Allow puma to be restarted by `rails restart` command.
 plugin(:tmp_restart)


### PR DESCRIPTION
Preload_app! is only relevant when `workers` is set to `> 0` (which it is), but Puma will default to `preload_app!` when `workers` is set to `> 0`, so we don't need to set it explicitly

Since Puma 5.x https://github.com/puma/puma/blob/fd259b7f1a64a505b694cd7cdef605a7de731611/History.md?plain=1#L377