### PR TITLE
Ignore predefined patterns when sending RoutingError to Rollbar

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -12,13 +12,21 @@ class ErrorsController < ActionController::Base
       format.any { render json: { error: "Page not found" }, status: :not_found }
     end
 
-    return unless request.referer
+    return if !request.referer || ignored_route_pattern?
 
     Rollbar.warning(
       ["RoutingError: No route matches",
        "[#{request.method}]",
        "'#{request.original_url}'"].join(" ")
     )
+  end
+
+  private
+
+  def ignored_route_pattern?
+    [".php", ".xml", ".txt", ".css", ".zip", ".gz"].any? do |ignored_route_pattern|
+      request.path.downcase.include?(ignored_route_pattern)
+    end
   end
 end
 # rubocop:enable Rails/ApplicationController

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -34,4 +34,23 @@ RSpec.describe ErrorsController do
       end
     end
   end
+
+  context "when route includes ignored route pattern" do
+    it "renders 404 status page and does not send warning to Rollbar" do
+      allow(Rollbar).to receive(:warning)
+
+      Rails.application.routes.draw do
+        get "/test.php" => "errors#not_found"
+      end
+
+      controller.request.headers.merge({ HTTP_REFERER: "https://example.com/" })
+
+      get :not_found, params: { use_route: "/test.php" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(Rollbar).to_not(have_received(:warning))
+
+      Rails.application.reload_routes!
+    end
+  end
 end


### PR DESCRIPTION
https://app.asana.com/0/1142794766483633/1204570621030669