### PR TITLE
Configure separate mailer queue with higher priority

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,7 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "project_name_snake_production"
+  config.action_mailer.deliver_later_queue_name = "mailers"
 
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :smtp

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
 :concurrency: 5
 :queues:
-  - default
-  - mailers
+  - [mailers, 4]
+  - [default, 1]


### PR DESCRIPTION
Ensure timely email delivery by configuring a dedicated "mailers" queue in Active Job and prioritizing it over the default queue in Sidekiq settings.

https://app.asana.com/0/1142794766483633/1205698639804494