### PR TITLE
Report Javascript errors to Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -72,4 +72,13 @@ Rollbar.configure do |config|
   # setup for Heroku. See:
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
   config.environment = ENV.fetch("ROLLBAR_ENV", nil).presence || Rails.env
+
+  config.js_enabled = true
+  config.js_options = {
+    accessToken: ENV.fetch("ROLLBAR_CLIENT_ACCESS_TOKEN", nil),
+    captureUncaught: true,
+    payload: {
+      environment: ENV.fetch("ROLLBAR_ENV", nil).presence || Rails.env
+    }
+  }
 end


### PR DESCRIPTION
- Injects middleware to provide the js snippet.
- When creating the access token, use the post_client_access_token. This token is exposed in the browser code (rollbar's recommended approach).