### PR TITLE
RackAttack: Enhanced security with updated rate limits

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -30,7 +30,10 @@ module Rack
     # Throttle all requests by IP (60rpm)
     #
     # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
-    throttle("req/ip", limit: 300, period: 5.minutes, &:ip)
+    throttle("req/ip",
+             limit: ENV.fetch("RACK_ATTACK_THROTTLE_LIMIT", "300").to_i,
+             period: ENV.fetch("RACK_ATTACK_THROTTLE_PERIOD", "5").to_i.minutes,
+             &:ip)
 
     ### Prevent Brute-Force Login Attacks ###
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,82 @@
 # frozen_string_literal: true
 
-Rack::Attack.throttle("requests by ip", limit: 20, period: 2, &:ip)
-Rack::Attack.blocklist_ip(ENV.fetch("BLOCKED_IPS")) if ENV.fetch("BLOCKED_IPS", nil).present?
-Rack::Attack.enabled = Rails.env.production? || ENV.key?("ENABLE_RACK_ATTACK")
+module Rack
+  class Attack
+    Rack::Attack.enabled = Rails.env.production? || ENV["ENABLE_RACK_ATTACK"].present?
+
+    Rack::Attack.blocklist_ip(ENV["BLOCKED_IPS"]) if ENV["BLOCKED_IPS"].present?
+
+    ### Configure Cache ###
+
+    # If you don't want to use Rails.cache (Rack::Attack's default), then
+    # configure it here.
+    #
+    # Note: The store is only used for throttling (not blocklisting and
+    # safelisting). It must implement .increment and .write like
+    # ActiveSupport::Cache::Store
+
+    # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+    ### Throttle Spammy Clients ###
+
+    # If any single client IP is making tons of requests, then they're
+    # probably malicious or a poorly-configured scraper. Either way, they
+    # don't deserve to hog all of the app server's CPU. Cut them off!
+    #
+    # Note: If you're serving assets through rack, those requests may be
+    # counted by rack-attack and this throttle may be activated too
+    # quickly. If so, enable the condition to exclude them from tracking.
+
+    # Throttle all requests by IP (60rpm)
+    #
+    # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+    throttle("req/ip", limit: 300, period: 5.minutes, &:ip)
+
+    ### Prevent Brute-Force Login Attacks ###
+
+    # The most common brute-force login attack is a brute-force password
+    # attack where an attacker simply tries a large number of emails and
+    # passwords to see if any credentials match.
+    #
+    # Another common method of attack is to use a swarm of computers with
+    # different IPs to try brute-forcing a password for a specific account.
+
+    # Throttle POST requests to users/sign_in by IP address
+    #
+    # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+    throttle("logins/ip", limit: 5, period: 20.seconds) do |req|
+      req.ip if req.path == "/users/sign_in" && req.post?
+    end
+
+    # Throttle POST requests to users/sign_in by email param
+    #
+    # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{normalized_email}"
+    #
+    # Note: This creates a problem where a malicious user could intentionally
+    # throttle logins for another user and force their login requests to be
+    # denied, but that's not very common and shouldn't happen to you. (Knock
+    # on wood!)
+    throttle("logins/email", limit: 5, period: 20.seconds) do |req|
+      if req.path == "/users/sign_in" && req.post?
+        # Normalize the email, using the same logic as your authentication process, to
+        # protect against rate limit bypasses. Return the normalized email if present,
+        # nil otherwise.
+        req.params["email"].to_s.downcase.gsub(/\s+/, "").presence
+      end
+    end
+
+    ### Custom Throttle Response ###
+
+    # By default, Rack::Attack returns an HTTP 429 for throttled responses,
+    # which is just fine.
+    #
+    # If you want to return 503 so that the attacker might be fooled into
+    # believing that they've successfully broken your app (or you just want to
+    # customize the response), then uncomment these lines.
+    # self.throttled_responder = lambda do |env|
+    #  [ 503,  # status
+    #    {},   # headers
+    #    ['']] # body
+    # end
+  end
+end

--- a/spec/rack/attack_spec.rb
+++ b/spec/rack/attack_spec.rb
@@ -73,14 +73,14 @@ RSpec.describe Rack::Attack, type: :request do
         # Make the allowed number of login attempts
         limit.times do
           post "/users/sign_in",
-               params: { user: { email: email, password: password } },
+               params: { user: { email:, password: } },
                env: { "REMOTE_ADDR" => ip_address }
           expect(response).to_not have_http_status(:too_many_requests)
         end
 
         # Make one more attempt which should be throttled
         post "/users/sign_in",
-             params: { user: { email: email, password: password } },
+             params: { user: { email:, password: } },
              env: { "REMOTE_ADDR" => ip_address }
         expect(response).to have_http_status(:too_many_requests)
       end
@@ -95,12 +95,12 @@ RSpec.describe Rack::Attack, type: :request do
       freeze_time do
         # Make the allowed number of login attempts with the same email
         limit.times do
-          post "/users/sign_in", params: { user: { email: email, password: "incorrect" } }
+          post "/users/sign_in", params: { user: { email:, password: "incorrect" } }
           expect(response).to_not have_http_status(:too_many_requests)
         end
 
         # Make one more attempt which should be throttled
-        post "/users/sign_in", params: { user: { email: email, password: "incorrect" } }
+        post "/users/sign_in", params: { user: { email:, password: "incorrect" } }
         expect(response).to have_http_status(:too_many_requests)
       end
     end

--- a/spec/rack/attack_spec.rb
+++ b/spec/rack/attack_spec.rb
@@ -5,8 +5,18 @@ require "rails_helper"
 RSpec.describe Rack::Attack, type: :request do
   include ActiveSupport::Testing::TimeHelpers
 
+  def requests_to_force_limit(limit)
+    # In Rack::Attack, requests are tracked using cache keys that reset after a specific period,
+    # similar to a bucket being emptied. For example, if a bucket (cache key) can hold up to 300
+    # requests (balls) and is emptied every 5 minutes, starting at a random time means we might
+    # not hit the limit by just exceeding it slightly. By sending double the limit plus one,
+    # (601 requests in this case), we ensure at least one bucket overflows,
+    # effectively testing the throttle. This method accounts for the uncertainty of when the bucket
+    # resets, guaranteeing we trigger the rate limit at least once within any given period.
+    (limit * 2) + 1
+  end
+
   before do
-    # Use memory cache store for this test
     memory_store = ActiveSupport::Cache.lookup_store(:memory_store)
     allow(Rails).to receive(:cache).and_return(memory_store)
     allow(Rack::Attack).to receive(:enabled).and_return(true)
@@ -14,47 +24,84 @@ RSpec.describe Rack::Attack, type: :request do
   end
 
   describe "IP address throttling" do
-    let(:limit) { 20 }
+    let(:limit) { 300 }
 
     context "when the number of requests does not exceed the limit" do
       it "does not change the request status" do
-        freeze_time do
-          limit.times do
-            get "/", env: { REMOTE_ADDR: "1.2.3.4" }
-            expect(response).to_not(have_http_status(:too_many_requests))
-          end
+        limit.times do
+          get "/", env: { REMOTE_ADDR: "1.2.3.4" }
+          expect(response).to_not have_http_status(:too_many_requests)
         end
       end
     end
 
     context "when the number of requests is higher than the limit" do
       it "changes the request status to 429" do
-        freeze_time do
+        statuses = []
+
+        requests_to_force_limit(limit).times do |i|
+          get "/", env: { REMOTE_ADDR: "1.2.3.5" }
+          statuses[i] = response.status
+        end
+
+        expect(statuses).to include(429)
+      end
+
+      context "when the IP addresses are not the same" do
+        it "doesn't throttle the requests" do
           statuses = []
 
-          (limit + 1).times do |i|
-            get "/", env: { REMOTE_ADDR: "1.2.3.5" }
+          requests_to_force_limit(limit).times do |i|
+            get "/", env: { REMOTE_ADDR: "1.2.3.#{i}" }
             statuses[i] = response.status
           end
 
-          expect(statuses).to include(429)
+          expect(statuses).to_not include(429)
         end
       end
+    end
+  end
 
-      context "when the IP-adresses are not the same" do
-        it "doesn't throttle the requests" do
-          freeze_time do
-            statuses = []
+  describe "throttle logins by IP address" do
+    it "throttles excessive login attempts by IP address" do
+      freeze_time do
+        limit = 5
+        email = "user@example.com"
+        password = "incorrect"
+        ip_address = "1.2.3.4"
 
-            (limit + 1).times do |i|
-              get "/", env: { REMOTE_ADDR: "1.2.3.#{i}" },
-                       headers: { "action_dispatch.show_exceptions": "1" }
-              statuses[i] = response.status
-            end
-
-            expect(statuses).to_not(include(429))
-          end
+        # Make the allowed number of login attempts
+        limit.times do
+          post "/users/sign_in",
+               params: { user: { email: email, password: password } },
+               env: { "REMOTE_ADDR" => ip_address }
+          expect(response).to_not have_http_status(:too_many_requests)
         end
+
+        # Make one more attempt which should be throttled
+        post "/users/sign_in",
+             params: { user: { email: email, password: password } },
+             env: { "REMOTE_ADDR" => ip_address }
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
+  end
+
+  describe "throttle logins by email address" do
+    it "throttles excessive login attempts by email address" do
+      limit = 5
+      email = "user@example.com"
+
+      freeze_time do
+        # Make the allowed number of login attempts with the same email
+        limit.times do
+          post "/users/sign_in", params: { user: { email: email, password: "incorrect" } }
+          expect(response).to_not have_http_status(:too_many_requests)
+        end
+
+        # Make one more attempt which should be throttled
+        post "/users/sign_in", params: { user: { email: email, password: "incorrect" } }
+        expect(response).to have_http_status(:too_many_requests)
       end
     end
   end


### PR DESCRIPTION
Expanded the Rack::Attack configuration to tighten security by refining throttling rules and rate limits to protect against brute-force attacks and DDoS attempts. Adjusted the general IP-based request limit to 300 requests every 5 minutes, significantly enhancing defenses against high-volume traffic abuses. Also introduced specific throttles on login attempts by IP and email address to mitigate brute-force login attacks, capped at 5 requests within a 20-second window. Updated tests to align with the new rate limit configurations, ensuring robust validation of the protective measures. The changes prepare the application for scenarios involving high traffic and potential malicious activities without affecting legitimate users' access under normal conditions.