### PR TITLE
Upgrade to shakapacker 8 rc3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "rack-attack"
 gem "rails", "~> 7.1.2"
 gem "rails-i18n"
 gem "rollbar"
-gem "shakapacker", "7.1.0"
+gem "shakapacker", "8.0.0.rc.3"
 gem "sidekiq"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    package_json (0.1.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -362,8 +363,9 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    shakapacker (7.1.0)
+    shakapacker (8.0.0.rc.3)
       activesupport (>= 5.2)
+      package_json
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
@@ -453,7 +455,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver (>= 4.11)
-  shakapacker (= 7.1.0)
+  shakapacker (= 8.0.0.rc.3)
   shoulda-matchers
   sidekiq
   simplecov

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-dom": "^18.2.0",
         "sass": "^1.72.0",
         "sass-loader": "^13.3.2",
-        "shakapacker": "7.1.0",
+        "shakapacker": "8.0.0-rc.3",
         "style-loader": "^3.3.4",
         "tailwindcss": "^3.4.1",
         "terser-webpack-plugin": "^5.3.10",
@@ -13280,18 +13280,16 @@
       "license": "ISC"
     },
     "node_modules/shakapacker": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-7.1.0.tgz",
-      "integrity": "sha512-xKfF4LKrFQdMLYeIi/uBV6pfkPTO4lgCAIMx3W5+MHW61ENOXu4WeQ50qVR9u5hV6XXzi7AiS7C6dWO2GFnYAg==",
-      "license": "MIT",
+      "version": "8.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-8.0.0-rc.3.tgz",
+      "integrity": "sha512-+KKK1QqVYj/BD+ymoE4y8IwjoexpuvEB8PzLtadDJXmhosKLYP8NudRtw3bDyjuzwGW+jbHfAWHhs+RuToZfCA==",
       "dependencies": {
-        "glob": "^7.2.0",
         "js-yaml": "^4.1.0",
         "path-complete-extname": "^1.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14 || >=16",
-        "yarn": ">=1 <4"
+        "node": ">= 14",
+        "yarn": ">=1 <5"
       },
       "peerDependencies": {
         "@babel/core": "^7.17.9",
@@ -13301,12 +13299,12 @@
         "@types/babel__core": "^7.0.0",
         "@types/webpack": "^5.0.0",
         "babel-loader": "^8.2.4 || ^9.0.0",
-        "compression-webpack-plugin": "^9.0.0 || ^10.0.0",
+        "compression-webpack-plugin": "^9.0.0 || ^10.0.0|| ^11.0.0",
         "terser-webpack-plugin": "^5.3.1",
         "webpack": "^5.72.0",
         "webpack-assets-manifest": "^5.0.6",
         "webpack-cli": "^4.9.2 || ^5.0.0",
-        "webpack-dev-server": "^4.9.0",
+        "webpack-dev-server": "^4.9.0 || ^5.0.0",
         "webpack-merge": "^5.8.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^18.2.0",
     "sass": "^1.72.0",
     "sass-loader": "^13.3.2",
-    "shakapacker": "7.1.0",
+    "shakapacker": "8.0.0-rc.3",
     "style-loader": "^3.3.4",
     "tailwindcss": "^3.4.1",
     "terser-webpack-plugin": "^5.3.10",


### PR DESCRIPTION
It turns out that shakapacker 7 requires yarn.
I have upgraded to 8 rc3. If it works fine I think it's better than having a "silent" yarn requirement. Hopefully it will be released in a stable version shortly.