### PR TITLE
Rubocop: Remove TargetRubyVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,6 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   NewCops: enable
-  TargetRubyVersion: 3.2
   Severity: error
 
   Exclude:


### PR DESCRIPTION
Less places to update when upgrading.
It will use the version from `.ruby-version`

https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version
> If a TargetRubyVersion is not specified in your config, then RuboCop will check your project for a series of other files where the Ruby version may be specified already. The files that will be checked are (in this order): *.gemspec, .ruby-version, .tool-versions, and Gemfile.lock.