### PR TITLE
Only enable `enable_reloading` if using Spring

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = false
+  config.cache_classes = !defined?(Spring)
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = !defined?(Spring)
+  config.enable_reloading = defined?(Spring)
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
Only enable `enable_reloading` if run through `bin/spring rspec`

`enable_reloading` is the new naming for that configuration option.
By default it is `false` in test.rb for a new Rails app.
Spring requires it `true`, so set it true when Spring is being used.