### PR TITLE
Devise: Workaround deprecation warning

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -21,7 +21,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2d4ac5fc04bdf9d4862c55104980520a4f7c63563e92df3b14d237b2135a73b7'
+  config.secret_key = Rails.application.secret_key_base
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.


### PR DESCRIPTION
Can be reverted once https://github.com/heartcombo/devise/issues/5644 is resolved

Was causing this warning:
https://github.com/abtion/rails-template/actions/runs/9657664443/job/26637340275#step:10:11
> DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /home/runner/work/rails-template/rails-template/config/environment.rb:7)