### PR TITLE
Fix deprecation: Rails 7.1 fixture_paths

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,9 @@ Dir.glob("./spec/support/**/*.rb").each { |f| require f }
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join("spec", "fixtures")
+  config.fixture_paths = [
+    Rails.root.join("spec", "fixtures")
+  ]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Was causing this warning:
https://github.com/abtion/rails-template/actions/runs/9657664443/job/26637340275#step:10:36
> Rails 7.1 has deprecated the singular fixture_path in favour of an array.You should migrate to plural: