### PR TITLE
Update Ruby and Bundler

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.2.3
+ruby 3.3.3
 nodejs 18.14.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,7 +475,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.3p157
+   ruby 3.3.3p89
 
 BUNDLED WITH
-   2.2.33
+   2.5.14


### PR DESCRIPTION
Also fixes:
```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```
and
```
warning: parser/current is loading parser/ruby32, which recognizes 3.2.4-compliant syntax, but you are running 3.2.3.
```