### PR TITLE
Upgrade Ruby 3.3.3 => 3.3.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.3.3
+ruby 3.3.4
 nodejs 18.14.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -481,7 +481,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.3.3p89
+   ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.14
+   2.5.16


### PR DESCRIPTION
This removes a deprecation warning about `ruby` and `parser` gem mismatch.

Not going to 3.3.5 because it prints a deprecation warning with the current version of `pry` (fixed in `master`, waiting for a release).

Clean the deprecation warning for #2330 