### PR TITLE
Gemfile: Use `ruby file: ".tool-versions"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-# In bundler 2.4.22 you can do `ruby file: ".tool-versions"`, but heroku uses an old bundler
-/^ruby (?<version>\d+\.\d+\.\d+)$/ =~ File.read(File.join(__dir__, ".tool-versions"))
-ruby version
+ruby file: ".tool-versions"
 
 gem "awesome_print"
 gem "bootsnap", ">= 1.4.4", require: false


### PR DESCRIPTION
https://devcenter.heroku.com/changelog-items/2808
> `BUNDLED WITH` 2.5.x and above will receive bundler 2.5.6