### PR TITLE
README.example.md: Update observatory badge link

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -1,6 +1,6 @@
 # Project Name Human
 
-[![Observatory](https://img.shields.io/mozilla-observatory/grade-score/abtion-rails-template.herokuapp.com)](https://observatory.mozilla.org/analyze/abtion-rails-template.herokuapp.com)
+[![Observatory](https://img.shields.io/mozilla-observatory/grade-score/abtion-rails-template.herokuapp.com)](https://developer.mozilla.org/en-US/observatory/analyze?host=abtion-rails-template.herokuapp.com)
 
 This project is built on top of the [Abtion Rails Template](https://github.com/abtion/rails-template).
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/blog/mdn-http-observatory-launch/
> The [old Mozilla Observatory](https://observatory.mozilla.org/) ... has been deprecated and will be sunset in September 2024.

I wonder what will happen when they "sunset" it. Will the old link redirect to the new http observatory?

Let's wait with merging this until we see the "sunset".